### PR TITLE
change miner count rounding

### DIFF
--- a/src/sites/tari-dot-com/ui/Header/ActiveMiners/ActiveMiners.tsx
+++ b/src/sites/tari-dot-com/ui/Header/ActiveMiners/ActiveMiners.tsx
@@ -1,15 +1,14 @@
-import { useMinerStats } from "@/services/api/useMinerStats";
-import { Dot, TextWrapper, Text, NumberWrapper, } from "./styles";
-import { useEffect, useRef, useState } from "react";
-import dynamic from "next/dynamic";
+import { useMinerStats } from '@/services/api/useMinerStats';
+import { Dot, TextWrapper, Text, NumberWrapper } from './styles';
+import { useEffect, useRef, useState } from 'react';
+import dynamic from 'next/dynamic';
 const NumberFlow = dynamic(() => import('@number-flow/react'), { ssr: false });
-
 
 interface Props {
     theme: 'light' | 'dark';
 }
 
-export default function ActiveMiners({ theme, }: Props) {
+export default function ActiveMiners({ theme }: Props) {
     const { data } = useMinerStats();
     const countValue = data?.totalMiners ?? 0;
     const [numberWidth, setNumberWidth] = useState(26);
@@ -22,22 +21,24 @@ export default function ActiveMiners({ theme, }: Props) {
         }
     }, [countValue]);
 
-    return <TextWrapper>
-        <Dot $theme={theme} />
-        <Text $theme={theme}>
-            <NumberWrapper style={{ width: `${numberWidth}px` }}>
-                <span ref={numberRef}>
-                    <NumberFlow
-                        value={countValue}
-                        format={{
-                            notation: countValue > 10000 ? 'compact' : 'standard',
-                            compactDisplay: 'short',
-                            maximumFractionDigits: 1,
-                        }}
-                    />
-                </span>
-            </NumberWrapper>
-            active miners
-        </Text>
-    </TextWrapper>
+    return (
+        <TextWrapper>
+            <Dot $theme={theme} />
+            <Text $theme={theme}>
+                <NumberWrapper style={{ width: `${numberWidth}px` }}>
+                    <span ref={numberRef}>
+                        <NumberFlow
+                            value={countValue}
+                            format={{
+                                notation: countValue > 100000 ? 'compact' : 'standard',
+                                compactDisplay: 'short',
+                                maximumFractionDigits: 1,
+                            }}
+                        />
+                    </span>
+                </NumberWrapper>
+                active miners
+            </Text>
+        </TextWrapper>
+    );
 }


### PR DESCRIPTION
Change active miner count to show full amount for numbers up to 100,000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved code readability and consistency in the ActiveMiners component.

- **Style**
  - Updated formatting and indentation for better visual clarity.

- **New Features**
  - Adjusted number display: numbers now switch to compact notation only when exceeding 100,000, making most values easier to read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->