### PR TITLE
feat: Add Google Analytics gtag script

### DIFF
--- a/src/ui-shared/layouts/Layout/Layout.tsx
+++ b/src/ui-shared/layouts/Layout/Layout.tsx
@@ -36,6 +36,18 @@ export default function Layout({ children }: { children: React.ReactNode }) {
                         data-search-mode-enabled="true"
                         strategy="afterInteractive"
                     />
+                    <Script
+                        src="https://www.googletagmanager.com/gtag/js?id=G-MG7C9LNNYV"
+                        strategy="afterInteractive"
+                    />
+                    <Script id="gtag-init" strategy="afterInteractive">
+                        {`
+                            window.dataLayer = window.dataLayer || [];
+                            function gtag(){dataLayer.push(arguments);}
+                            gtag('js', new Date());
+                            gtag('config', 'G-MG7C9LNNYV');
+                        `}
+                    </Script>
                 </body>
             </html>
         </Providers>


### PR DESCRIPTION
This commit adds the Google Analytics gtag script to the Layout component. This allows us to track user behavior on the site and gain insights into how users are interacting with our content. The script is added using Next.js's Script component with the `afterInteractive` strategy for optimal performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated Google Analytics tracking to monitor site usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->