### PR TITLE
feat: Add GTM event tracking to download buttons

### DIFF
--- a/src/ui-shared/components/DownloadButton/DownloadForOs.tsx
+++ b/src/ui-shared/components/DownloadButton/DownloadForOs.tsx
@@ -3,21 +3,31 @@ import MacIcon from '../Icons/MacIcon';
 import LinuxIcon from '../Icons/LinuxIcon';
 import WindowsIcon from '../Icons/WindowsIcon';
 import Typography from '../Typography/Typography';
+import { sendGTMEvent } from '@next/third-parties/google';
 
 function DownloadForOs() {
+    const handleClick = (platform?: string) => {
+        sendGTMEvent({ event: 'download_button_clicked', platform: platform });
+    };
     return (
         <>
             <Typography $variant="h5">Download Tari Universe now</Typography>
             <ButtonsWrapper>
-                <OsButton href="https://airdrop.tari.com/api/miner/download/macos?universeReferral=tari-dot-com">
+                <OsButton href="https://airdrop.tari.com/api/miner/download/macos?universeReferral=tari-dot-com"
+                    onClick={() => handleClick('macos')}
+                >
                     Mac
                     <MacIcon fill="#000" />
                 </OsButton>
-                <OsButton href="https://airdrop.tari.com/api/miner/download/windows?universeReferral=tari-dot-com">
+                <OsButton href="https://airdrop.tari.com/api/miner/download/windows?universeReferral=tari-dot-com"
+                    onClick={() => handleClick('windows')}
+                >
                     Windows
                     <WindowsIcon fill="#000" />
                 </OsButton>
-                <OsButton href="https://airdrop.tari.com/api/miner/download/linux?universeReferral=tari-dot-com">
+                <OsButton href="https://airdrop.tari.com/api/miner/download/linux?universeReferral=tari-dot-com"
+                    onClick={() => handleClick('linux')}
+                >
                     Linux
                     <LinuxIcon fill="#000" />
                 </OsButton>


### PR DESCRIPTION
This commit adds Google Tag Manager (GTM) event tracking to the download buttons for MacOS, Windows, and Linux. When a user clicks on a download button, a `download_button_clicked` event is sent to GTM, along with the platform (macos, windows, or linux) that was clicked. This will allow us to track which platforms are being downloaded most frequently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added event tracking for download button clicks on different operating systems. Users' interactions with Mac, Windows, and Linux download buttons are now tracked for analytics purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->