### PR TITLE
feat: Use exchange data for download links

### DIFF
--- a/src/services/api/fetchExchangeData.ts
+++ b/src/services/api/fetchExchangeData.ts
@@ -29,11 +29,11 @@ export async function fetchExchangeData(exchangeId: string): Promise<Exchange> {
             is_hidden: false,
             // Download links
             download_link_linux:
-                'https://github.com/tari-project/tari-universe/releases/download/v0.1.0/tari-universe-linux-x86_64-v0.1.0.tar.gz',
+                'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
             download_link_mac:
-                'https://github.com/tari-project/tari-universe/releases/download/v0.1.0/tari-universe-macos-x86_64-v0.1.0.tar.gz',
+                'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
             download_link_win:
-                'https://github.com/tari-project/tari-universe/releases/download/v0.1.0/tari-universe-windows-x86_64-v0.1.0.zip',
+                'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
             // Reward missing fields
             reward_image:
                 'https://github.com/tari-project/tari-universe/releases/download/v0.1.0/tari-universe-windows-x86_64-v0.1.0.zip',

--- a/src/services/api/useDownloadUniverse.ts
+++ b/src/services/api/useDownloadUniverse.ts
@@ -1,5 +1,6 @@
 export type DownloadPlatform = 'windows' | 'macos' | 'linux';
 import { sendGTMEvent } from '@next/third-parties/google';
+import { useExchangeData } from './useExchangeData';
 
 export const getPlatform = () => {
     const userAgent = typeof window !== 'undefined' ? window.navigator.userAgent : '';
@@ -22,12 +23,28 @@ const checkIsMobile = () => {
 };
 
 export const useDownloadUniverse = () => {
+    const { data: exchange } = useExchangeData();
     const handleDownload = (platform?: DownloadPlatform) => {
         if (!platform) {
             platform = getPlatform();
         }
         const url = `https://airdrop.tari.com/api/miner/download/${platform}?universeReferral=tari-dot-com`;
         sendGTMEvent({ event: 'download_button_clicked', platform: platform });
+        const {
+            download_link_mac: macLink,
+            download_link_linux: linuxLink,
+            download_link_win: winLink,
+        } = exchange || {};
+
+        if (exchange) {
+            if (platform === 'macos' && macLink) {
+                window.open(macLink, '_blank');
+            } else if (platform === 'linux' && linuxLink) {
+                window.open(linuxLink, '_blank');
+            } else if (platform === 'windows' && winLink) {
+                window.open(winLink, '_blank');
+            }
+        }
 
         window.open(url, '_blank');
     };

--- a/src/services/api/useDownloadUniverse.ts
+++ b/src/services/api/useDownloadUniverse.ts
@@ -39,10 +39,13 @@ export const useDownloadUniverse = () => {
         if (exchange) {
             if (platform === 'macos' && macLink) {
                 window.open(macLink, '_blank');
+                return;
             } else if (platform === 'linux' && linuxLink) {
                 window.open(linuxLink, '_blank');
+                return;
             } else if (platform === 'windows' && winLink) {
                 window.open(winLink, '_blank');
+                return;
             }
         }
 

--- a/src/sites/tari-dot-com/ui/Modals/DownloadModal/DownloadModal.tsx
+++ b/src/sites/tari-dot-com/ui/Modals/DownloadModal/DownloadModal.tsx
@@ -17,9 +17,15 @@ import MacIcon from '@/ui-shared/components/Icons/MacIcon';
 import LinuxIcon from '@/ui-shared/components/Icons/LinuxIcon';
 import tariLogoImage from './images/tariLogo.png';
 import { sendGTMEvent } from '@next/third-parties/google';
+import { useExchangeData } from '@/services/api/useExchangeData';
 
 export default function DownloadModal() {
     const { showDownloadModal, setShowDownloadModal } = useUIStore();
+    const { data: exchange } = useExchangeData();
+
+    const windowsLink = exchange?.download_link_win || 'https://airdrop.tari.com/api/miner/download/windows?universeReferral=tari-dot-com';
+    const macLink = exchange?.download_link_mac || 'https://airdrop.tari.com/api/miner/download/macos?universeReferral=tari-dot-com';
+    const linuxLink = exchange?.download_link_linux || 'https://airdrop.tari.com/api/miner/download/linux?universeReferral=tari-dot-com';
 
     const handleClick = (platform?: string) => {
         sendGTMEvent({ event: 'download_button_clicked', platform: platform });
@@ -43,19 +49,19 @@ export default function DownloadModal() {
 
                 <DownloadButtons>
                     <DownloadButton
-                        href="https://airdrop.tari.com/api/miner/download/windows?universeReferral=tari-dot-com"
+                        href={windowsLink}
                         onClick={() => handleClick('windows')}
                     >
                         WINDOWS <WindowsIcon fill="#fff" />
                     </DownloadButton>
                     <DownloadButton
-                        href="https://airdrop.tari.com/api/miner/download/macos?universeReferral=tari-dot-com"
+                        href={macLink}
                         onClick={() => handleClick('macos')}
                     >
                         MAC <MacIcon fill="#fff" />
                     </DownloadButton>
                     <DownloadButton
-                        href="https://airdrop.tari.com/api/miner/download/linux?universeReferral=tari-dot-com"
+                        href={linuxLink}
                         onClick={() => handleClick('linux')}
                     >
                         Linux <LinuxIcon fill="#fff" />


### PR DESCRIPTION
Refactor download links to use data fetched from the exchange API. This allows for dynamic download links based on exchange configurations. Includes updates to the DownloadModal and useDownloadUniverse hook to utilize the new exchange data. Also, temporarily replaced download links in `fetchExchangeData.ts` with rickrolls.