### PR TITLE
feat: Add exchange name to download button GTM ...

### DIFF
--- a/src/services/api/useDownloadUniverse.ts
+++ b/src/services/api/useDownloadUniverse.ts
@@ -29,13 +29,13 @@ export const useDownloadUniverse = () => {
             platform = getPlatform();
         }
         const url = `https://airdrop.tari.com/api/miner/download/${platform}?universeReferral=tari-dot-com`;
-        sendGTMEvent({ event: 'download_button_clicked', platform: platform });
         const {
             download_link_mac: macLink,
             download_link_linux: linuxLink,
             download_link_win: winLink,
         } = exchange || {};
 
+        sendGTMEvent({ event: 'download_button_clicked', platform: platform, exchange: exchange?.name });
         if (exchange) {
             if (platform === 'macos' && macLink) {
                 window.open(macLink, '_blank');


### PR DESCRIPTION
The download button click event in GTM was updated to include the exchange name for better tracking and analytics. The previous implementation was missing this context when a download occurred through an exchange link, limiting our understanding of which exchanges are driving downloads. This change adds the exchange name as a property to the `download_button_clicked` event, providing more granular insights into download sources.