### PR TITLE
feat: Improve Download Modal and Button logic

### DIFF
--- a/src/sites/tari-dot-com/pages/HomePage/sections/IntroSection/components/DownloadButton/DownloadButton.tsx
+++ b/src/sites/tari-dot-com/pages/HomePage/sections/IntroSection/components/DownloadButton/DownloadButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import AppleIcon from './icons/AppleIcon';
 import LinuxIcon from './icons/LinuxIcon';
@@ -62,14 +62,15 @@ export default function DownloadButton({
     const { setShowDownloadModal } = useUIStore();
     const { handleDownloadClick } = useDownloadUniverse();
 
-    const handleClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+    const shouldDownload = useMemo(() => !isVeera || searchParams.get('veeraEmailRef'), [isVeera, searchParams]);
+
+    const handleClick = useCallback((e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
         e.preventDefault();
-        const veeraEmailRef = searchParams.get('veeraEmailRef');
-        if (!isVeera || veeraEmailRef) {
+        if (shouldDownload) {
             handleDownloadClick(e);
         }
         setShowDownloadModal(true);
-    };
+    }, [handleDownloadClick, setShowDownloadModal, shouldDownload]);
 
     // Intersection Observer to detect if button is out of view
     useEffect(() => {
@@ -96,6 +97,7 @@ export default function DownloadButton({
             as={Link}
             href="/downloads"
             onClick={handleClick}
+            id={shouldDownload ? 'universe-download-button' : undefined}
             onMouseEnter={() => setHovering(true)}
             onMouseLeave={() => setHovering(false)}
             $backgroundColor={backgroundColor}

--- a/src/sites/tari-dot-com/ui/Modals/DownloadModal/DownloadModal.tsx
+++ b/src/sites/tari-dot-com/ui/Modals/DownloadModal/DownloadModal.tsx
@@ -151,7 +151,7 @@ export default function DownloadModal() {
                                 />
                             </FormFields>
                             {markup}
-                            <SubmitButton type="submit" disabled={isLoading || isSuccess || !token}>
+                            <SubmitButton type="submit" disabled={isLoading || isSuccess || !token} id={isVeera ? 'universe-download-button' : undefined}>
                                 <span>
                                     Let’s do it!{' '}
                                     <svg


### PR DESCRIPTION
- Added `useMemo` to determine if download should proceed based on `isVeera` and `veeraEmailRef` parameter.
- Used `useCallback` to memoize the `handleClick` function, preventing unnecessary re-renders.
- Added an id to both the Download Button and Submit Button in the Download Modal, which allows for easier targeting of elements for testing and analytics.