### PR TITLE
feat: Add dark logo support for exchanges

### DIFF
--- a/src/sites/exchange/pages/ExchangePage/sections/HeroSection/HeroHeader/HeroHeader.tsx
+++ b/src/sites/exchange/pages/ExchangePage/sections/HeroSection/HeroHeader/HeroHeader.tsx
@@ -7,13 +7,14 @@ import { isValidImage } from '@/sites/exchange/utils';
 
 export default function HeroHeader({ exchange }: { exchange: Exchange }) {
     const isVeera = exchange.id === 'veera';
+    const logoUrl = exchange?.dark_logo_img_url || exchange?.logo_img_url
     return (
         <Wrapper>
             <LogoWrapper>
                 <TariLogo />
                 <CrossIcon />
-                {isValidImage(exchange?.logo_img_url) ? (
-                    <LogoImage src={exchange.logo_img_url} alt={exchange?.name} $isVeera={isVeera} />
+                {isValidImage(logoUrl) ? (
+                    <LogoImage src={logoUrl} alt={exchange?.name} $isVeera={isVeera} />
                 ) : (
                     <div style={{ width: 121, height: 38, background: '#444', borderRadius: 8 }} />
                 )}

--- a/src/sites/exchange/types/exchange.ts
+++ b/src/sites/exchange/types/exchange.ts
@@ -9,11 +9,13 @@ export interface Exchange {
     campaign_description: string;
     wallet_label: string;
     hero_img: string;
-    exchange_id: string;
+    slug: string;
     primary_colour: string;
     secondary_colour: string;
     logo_img_url: string;
+    dark_logo_img_url: string;
     logo_img_small_url: string;
+    dark_logo_img_small_url: string;
     hero_img_url: string;
     is_hidden?: boolean;
     download_link_mac?: string;
@@ -22,4 +24,11 @@ export interface Exchange {
     reward_image?: string;
     reward_expiry_date?: string;
     reward_percentage?: number;
+    exchange_url: string;
+    address_help_link: string;
+    wallet_app_label: string;
+    wallet_app_link: string;
+    password: string;
+    wxtm_mode: boolean;
+    admin_only: boolean;
 }


### PR DESCRIPTION
This commit introduces support for displaying a dark logo for exchanges. It adds the `dark_logo_img_url` field to the `Exchange` type and updates the `HeroHeader` component to prioritize the dark logo when available. This allows for better visual adaptation on dark backgrounds or themes.