### PR TITLE
refactor: Make Exchange interface properties op...

### DIFF
--- a/src/sites/exchange/types/exchange.ts
+++ b/src/sites/exchange/types/exchange.ts
@@ -13,9 +13,9 @@ export interface Exchange {
     primary_colour: string;
     secondary_colour: string;
     logo_img_url: string;
-    dark_logo_img_url: string;
+    dark_logo_img_url?: string;
     logo_img_small_url: string;
-    dark_logo_img_small_url: string;
+    dark_logo_img_small_url?: string;
     hero_img_url: string;
     is_hidden?: boolean;
     download_link_mac?: string;
@@ -24,11 +24,11 @@ export interface Exchange {
     reward_image?: string;
     reward_expiry_date?: string;
     reward_percentage?: number;
-    exchange_url: string;
-    address_help_link: string;
-    wallet_app_label: string;
-    wallet_app_link: string;
-    password: string;
-    wxtm_mode: boolean;
-    admin_only: boolean;
+    exchange_url?: string;
+    address_help_link?: string;
+    wallet_app_label?: string;
+    wallet_app_link?: string;
+    password?: string;
+    wxtm_mode?: boolean;
+    admin_only?: boolean;
 }


### PR DESCRIPTION
Some properties in the Exchange interface are not always present in the exchange config. This change makes the following properties optional to reflect this: `dark_logo_img_url`, `dark_logo_img_small_url`, `exchange_url`, `address_help_link`, `wallet_app_label`, `wallet_app_link`, `password`, `wxtm_mode`, and `admin_only`.