### PR TITLE
Remove CMT Digital from site

### DIFF
--- a/src/sites/tari-dot-com/pages/HomePage/sections/EcosystemSection/components/Community/Track.tsx
+++ b/src/sites/tari-dot-com/pages/HomePage/sections/EcosystemSection/components/Community/Track.tsx
@@ -3,7 +3,6 @@
 import { TrackWrapper, TrackWidth, Track, Image } from './styles';
 import BlockchainCapital from './images/blockchain_capital.png';
 import ParisHilton from './images/paris_hilton.png';
-import CMTDigital from './images/cmtdigital.png';
 import GEAZY from './images/geazy.png';
 import GMoney from './images/gmoney.png';
 import Loomdart from './images/loomdart.png';
@@ -31,42 +30,36 @@ export default function TrackComponent() {
                 >
                     <Image src={BlockchainCapital.src} alt="Blockchain Capital" />
                     <Image src={ParisHilton.src} alt="Paris Hilton" />
-                    <Image src={CMTDigital.src} alt="CMT Digital" />
                     <Image src={GEAZY.src} alt="G-Eazy" />
                     <Image src={GMoney.src} alt="@gmoney" />
                     <Image src={Loomdart.src} alt="@loomdart" />
                     <Image src={LilWayne.src} alt="Lil Wayne" />
                     <Image src={BlockchainCapital.src} alt="Blockchain Capital" />
                     <Image src={ParisHilton.src} alt="Paris Hilton" />
-                    <Image src={CMTDigital.src} alt="CMT Digital" />
                     <Image src={GEAZY.src} alt="G-Eazy" />
                     <Image src={GMoney.src} alt="@gmoney" />
                     <Image src={Loomdart.src} alt="@loomdart" />
                     <Image src={LilWayne.src} alt="Lil Wayne" />
                     <Image src={BlockchainCapital.src} alt="Blockchain Capital" />
                     <Image src={ParisHilton.src} alt="Paris Hilton" />
-                    <Image src={CMTDigital.src} alt="CMT Digital" />
                     <Image src={GEAZY.src} alt="G-Eazy" />
                     <Image src={GMoney.src} alt="@gmoney" />
                     <Image src={Loomdart.src} alt="@loomdart" />
                     <Image src={LilWayne.src} alt="Lil Wayne" />
                     <Image src={BlockchainCapital.src} alt="Blockchain Capital" />
                     <Image src={ParisHilton.src} alt="Paris Hilton" />
-                    <Image src={CMTDigital.src} alt="CMT Digital" />
                     <Image src={GEAZY.src} alt="G-Eazy" />
                     <Image src={GMoney.src} alt="@gmoney" />
                     <Image src={Loomdart.src} alt="@loomdart" />
                     <Image src={LilWayne.src} alt="Lil Wayne" />
                     <Image src={BlockchainCapital.src} alt="Blockchain Capital" />
                     <Image src={ParisHilton.src} alt="Paris Hilton" />
-                    <Image src={CMTDigital.src} alt="CMT Digital" />
                     <Image src={GEAZY.src} alt="G-Eazy" />
                     <Image src={GMoney.src} alt="@gmoney" />
                     <Image src={Loomdart.src} alt="@loomdart" />
                     <Image src={LilWayne.src} alt="Lil Wayne" />
                     <Image src={BlockchainCapital.src} alt="Blockchain Capital" />
                     <Image src={ParisHilton.src} alt="Paris Hilton" />
-                    <Image src={CMTDigital.src} alt="CMT Digital" />
                     <Image src={GEAZY.src} alt="G-Eazy" />
                     <Image src={GMoney.src} alt="@gmoney" />
                     <Image src={Loomdart.src} alt="@loomdart" />

--- a/src/sites/tari-dot-com/pages/TokenomicsPage/TokenomicsPage.tsx
+++ b/src/sites/tari-dot-com/pages/TokenomicsPage/TokenomicsPage.tsx
@@ -249,7 +249,7 @@ export default function TokenomicsPage() {
                     <span>
                         Before Tari was a protocol, it was a vision. Participants are the early supporters such as
                         Blockchain Capital, Collab+Currency, gmoney, loomdart, DCF GOD, DV Chain, Kamal Ravikant, Bryan
-                        Pellegrino, Ayon, Messi, Pantera, Hack VC, Paris Hilton, eGirl Capital, CMT Digital, Kilowatt,
+                        Pellegrino, Ayon, Messi, Pantera, Hack VC, Paris Hilton, eGirl Capital, Kilowatt,
                         Redpoint, Trinity, and many others who stepped up to help make Tari a reality.{' '}
                     </span>
                     <strong>12%</strong>


### PR DESCRIPTION
Removes all references to CMT Digital:
- Removed image and import from the community scrolling track on the homepage
- Removed text mention from the TokenomicsPage supporters list