### PR TITLE
fix(mobile-header): offset mobile menu by actual promo banner height

### DIFF
--- a/src/sites/tari-dot-com/ui/Banner/PromoBanner.tsx
+++ b/src/sites/tari-dot-com/ui/Banner/PromoBanner.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { useASICModalStore } from '@/stores/useASICModalStore';
 import {
     NewBannerWrapper,
@@ -20,6 +21,31 @@ type Props = {
 
 export default function PromoBanner({ _children, onClick }: Props) {
     const { openModal } = useASICModalStore();
+    const bannerRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const bannerElement = bannerRef.current;
+
+        if (!bannerElement) {
+            return;
+        }
+
+        const rootStyle = document.documentElement.style;
+        const syncBannerHeight = () => {
+            const bannerHeight = Math.ceil(bannerElement.getBoundingClientRect().height);
+            rootStyle.setProperty('--promo-banner-height', `${bannerHeight}px`);
+        };
+
+        syncBannerHeight();
+
+        const resizeObserver = new ResizeObserver(syncBannerHeight);
+        resizeObserver.observe(bannerElement);
+
+        return () => {
+            resizeObserver.disconnect();
+            rootStyle.removeProperty('--promo-banner-height');
+        };
+    }, []);
 
     const handleClick = () => {
         if (onClick) {
@@ -30,7 +56,7 @@ export default function PromoBanner({ _children, onClick }: Props) {
     };
 
     return (
-        <NewBannerWrapper onClick={handleClick}>
+        <NewBannerWrapper ref={bannerRef} onClick={handleClick}>
             <BannerContent>
                 <ASICImage src="/asic-machine-banner.png" alt="ASIC Miner" />
                 <LeftSection>

--- a/src/sites/tari-dot-com/ui/Header/MobileHeader/styles.ts
+++ b/src/sites/tari-dot-com/ui/Header/MobileHeader/styles.ts
@@ -70,21 +70,25 @@ export const HeaderTop = styled(motion.div)<{ $open: boolean }>`
 `;
 
 export const Menu = styled(motion.div)`
+    --menu-top-offset: var(--promo-banner-height, 57px);
+
     box-shadow: 10px 10px 75px 0px rgba(0, 0, 0, 0.35);
     background: #0c0718;
     background-image: url(${headerBgImage.src});
     background-repeat: repeat;
     background-color: #0c0718;
     width: 100%;
-    height: 100dvh;
+    height: calc(100dvh - var(--menu-top-offset));
 
     position: fixed;
-    top: 0;
+    top: var(--menu-top-offset);
     left: 0;
     z-index: 98;
 
     padding: 30px;
-    padding-top: 100px;
+    padding-top: 45px;
+
+    overflow-y: auto;
 `;
 
 export const MenuHolder = styled.div`

--- a/src/sites/tari-dot-com/ui/Header/MobileHeader/styles.ts
+++ b/src/sites/tari-dot-com/ui/Header/MobileHeader/styles.ts
@@ -70,7 +70,7 @@ export const HeaderTop = styled(motion.div)<{ $open: boolean }>`
 `;
 
 export const Menu = styled(motion.div)`
-    --menu-top-offset: var(--promo-banner-height, 57px);
+    --menu-top-offset: var(--promo-banner-height, 0px);
 
     box-shadow: 10px 10px 75px 0px rgba(0, 0, 0, 0.35);
     background: #0c0718;


### PR DESCRIPTION
Description
---
Replace hardcoded mobile menu `top`/`height` offsets with a dynamic CSS custom property (`--promo-banner-height`) that tracks the actual rendered height of the ASIC promo banner via `ResizeObserver`. The mobile menu now always starts exactly below the banner regardless of its rendered size.

Motivation and Context
---
The mobile menu overlay used hardcoded `top` and `height` values (40px, 70px, 80px) at specific breakpoints to avoid overlapping the menu items. Because the banner uses `min-height` and `height: auto` on mobile, its actual height is dynamic and varies with content and screen width.
<img width="480" height="523" alt="Снимок экрана 2026-04-10 в 19 48 52" src="https://github.com/user-attachments/assets/9bd0dbed-5e37-43c6-87eb-4726c55734b9" />


How Has This Been Tested?
---
- Verified the menu positions correctly below the banner across multiple viewport widths.
- Confirmed `ResizeObserver` updates the CSS variable when the banner height changes (e.g., on window resize).
- Confirmed the menu remains scrollable (`overflow-y: auto`) with the dynamic height.
- ESLint passed for all modified files.

What process can a PR reviewer use to test or verify this change?
---
1. Open the site on a mobile viewport (or use DevTools responsive mode).
2. Open the mobile menu and confirm it starts directly below the ASIC banner with no overlap or gap.
3. Resize the browser window and verify the menu adjusts in real time.
4. Inspect the `<html>` element in DevTools and confirm `--promo-banner-height` updates dynamically.

## Breaking Changes

- [ ] None
- [ ] Requires data directory to be deleted
- [x] Other - Please specify.

The original problem was that when opening the mobile menu, the menu items were effectively hidden and not clickable. After the current MR, a visual nuance remains – when the 'About Tari' menu is open on mobile and scrolling appears within the mobile menu, there are a couple of pixels between the ASIC banner and the Tari bar with the close (X) button for closing the mobile menu. I’d fix that a bit later

