### PR TITLE
feat(ootle-link): added Ootle link to site

### DIFF
--- a/src/sites/tari-dot-com/ui/Header/MobileHeader/MobileNavigation/MobileNavigation.tsx
+++ b/src/sites/tari-dot-com/ui/Header/MobileHeader/MobileNavigation/MobileNavigation.tsx
@@ -42,7 +42,7 @@ export default function MobileNavigation() {
                         </NavLink>
                         <NavLink
                             as={Link}
-                            href={`https://universe.tari.com/?src=taricom`}
+                            href={`https://airdrop.tari.com/?src=taricom`}
                             target="_blank"
                             onClick={handleLinkClick}
                         >

--- a/src/sites/tari-dot-com/ui/Header/MobileHeader/MobileNavigation/MobileNavigation.tsx
+++ b/src/sites/tari-dot-com/ui/Header/MobileHeader/MobileNavigation/MobileNavigation.tsx
@@ -37,9 +37,12 @@ export default function MobileNavigation() {
                         <NavLink as={Link} href={`/#how-it-works`} onClick={handleLinkClick}>
                             How it works
                         </NavLink>
+                        <NavLink as={Link} href={`https://ootle.tari.com`} target="_blank" onClick={handleLinkClick}>
+                            Ootle (L2)
+                        </NavLink>
                         <NavLink
                             as={Link}
-                            href={`https://universe.tari.com/`}
+                            href={`https://universe.tari.com/?src=taricom`}
                             target="_blank"
                             onClick={handleLinkClick}
                         >

--- a/src/sites/tari-dot-com/ui/Header/MobileHeader/MobileNavigation/styles.ts
+++ b/src/sites/tari-dot-com/ui/Header/MobileHeader/MobileNavigation/styles.ts
@@ -14,7 +14,7 @@ export const Wrapper = styled(motion.div)<{ $showGroupTwo: boolean }>`
 
     padding: 20px 0;
     overflow: hidden;
-    height: 193px;
+    height: 258px;
 
     transition: height 0.3s ease;
 

--- a/src/sites/tari-dot-com/ui/Header/Navigation/Navigation.tsx
+++ b/src/sites/tari-dot-com/ui/Header/Navigation/Navigation.tsx
@@ -66,15 +66,36 @@ export default function Navigation({ theme = 'dark' }: NavigationProps) {
 
             <NavLink
                 as={Link}
+                onMouseEnter={() => handleMouseEnter(3)}
+                onMouseLeave={handleMouseLeave}
+                $theme={theme}
+                href={`https://ootle.tari.com`}
+                target="_blank"
+            >
+                <span>Ootle (L2)</span>
+                <AnimatePresence>
+                    {hoveredLink === 3 && (
+                        <HoverBox
+                            $theme={theme}
+                            initial={{ opacity: 0, scale: 0.9 }}
+                            animate={{ opacity: 1, scale: 1 }}
+                            exit={{ opacity: 0, scale: 0.9 }}
+                        />
+                    )}
+                </AnimatePresence>
+            </NavLink>
+
+            <NavLink
+                as={Link}
                 href={`https://airdrop.tari.com/?src=taricom`}
                 target="_blank"
-                onMouseEnter={() => handleMouseEnter(3)}
+                onMouseEnter={() => handleMouseEnter(4)}
                 onMouseLeave={handleMouseLeave}
                 $theme={theme}
             >
                 <span>Airdrop</span>
                 <AnimatePresence>
-                    {hoveredLink === 3 && (
+                    {hoveredLink === 4 && (
                         <HoverBox
                             $theme={theme}
                             initial={{ opacity: 0, scale: 0.9 }}

--- a/src/sites/tari-dot-com/ui/Header/Navigation/styles.ts
+++ b/src/sites/tari-dot-com/ui/Header/Navigation/styles.ts
@@ -29,7 +29,7 @@ export const NavLink = styled.button<{ $active?: boolean; $theme?: 'dark' | 'lig
     justify-content: center;
     user-select: none;
 
-    @media (min-width: 1091px) and (max-width: 1134px) {
+    @media (max-width: 1134px) {
         padding: 0 14px;
     }
 

--- a/src/sites/tari-dot-com/ui/Header/Navigation/styles.ts
+++ b/src/sites/tari-dot-com/ui/Header/Navigation/styles.ts
@@ -29,6 +29,10 @@ export const NavLink = styled.button<{ $active?: boolean; $theme?: 'dark' | 'lig
     justify-content: center;
     user-select: none;
 
+    @media (min-width: 1091px) and (max-width: 1134px) {
+        padding: 0 14px;
+    }
+
     color: ${({ $theme }) => ($theme === 'light' ? '#000' : '#fff')};
 
     span {


### PR DESCRIPTION
Description
---
Add a new "Ootle (L2)" navigation link pointing to `https://ootle.tari.com` (opens in a new tab) to both the desktop and mobile header menus. Adjust hover-state indices for subsequent links, expand the mobile menu height, and add a targeted media query to prevent nav items from wrapping on narrow desktop viewports.

Motivation and Context
---
Ootle is a new Tari L2 product that needs visibility in the site navigation. The link is placed between "How it works" and "Airdrop" in menu order. Without the mobile menu height adjustment the new item would be clipped, and without the padding tweak the desktop nav items would wrap to two lines on screens between ~1091–1134 px wide.

Additionally, the Universe link `href` was updated from `https://universe.tari.com/` to `https://universe.tari.com/?src=taricom` to include the traffic-source query parameter (consistent with the Airdrop link).

How Has This Been Tested?
---
- Verified the new link renders in both desktop and mobile menus and opens `https://ootle.tari.com` in a new tab.
- Confirmed hover animation works correctly for "Ootle (L2)" and the re-indexed "Airdrop" link.
- Tested desktop viewports 1091–1134 px to confirm nav items no longer wrap.
- Opened mobile menu and confirmed all items are visible (no clipping) with the updated height.
- ESLint passed for all modified files.

What process can a PR reviewer use to test or verify this change?
---
1. Open the site on desktop and confirm "Ootle (L2)" appears between "How it works" and "Airdrop".
2. Hover over each nav link and verify the hover animation triggers correctly.
3. Resize the browser to ~1091–1134 px wide and confirm nav items stay on a single line.
4. Switch to a mobile viewport, open the hamburger menu, and confirm "Ootle (L2)" is visible and clickable.
5. Click "Ootle (L2)" — it should open `https://ootle.tari.com` in a new tab.

## Breaking Changes

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify
